### PR TITLE
Small types improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.7",
   "description": "",
   "main": "build/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "build/index.d.ts",
   "scripts": {
     "dev": "yarn tsc --watch",
     "build": "rm -rf ./build/* && tsc",

--- a/src/ImageCropper.tsx
+++ b/src/ImageCropper.tsx
@@ -17,7 +17,7 @@ interface IProps {
   setCropperParams: (params: IState) => void;
 }
 
-interface IState {
+export interface IState {
   positionX: number;
   positionY: number;
   width: number;
@@ -40,7 +40,7 @@ const defaultProps = {
 };
 
 class ImageCropper extends PureComponent<IProps, IState> {
-  static crop = (params: ICropParams) => {
+  static crop = (params: ICropParams): Promise<string | null | undefined> => {
     const {
       imageUri,
       cropSize,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 import ImageCropper from './ImageCropper';
 
 export default ImageCropper;
+
+export { IState } from './ImageCropper';
+export * from './types';


### PR DESCRIPTION
Hi @barrsan,

Thank you for such a great project. I was really happy to encounter it.

I applied it for my project and found small things which I'd like to improve:
1) Fix export types. In current implementation `TS` can't find `ImageCropper` component because in `package.json` path for types leads to 'build/types/index.d.ts'.
2) Add type annotation for `ImageCropper.crop` method because otherwise it's `unknown`
3) Export `IState` type because it helps to deal with `setCropperParams` prop.

Hope you agree with such changes.
