### PR TITLE
[WIP] Feature: cropArea option

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -12,6 +12,7 @@ const h = window.width;
 // const IMAGE = 'https://picsum.photos/id/48/500/900';
 const IMAGE = 'https://picsum.photos/id/48/900/900';
 const IMAGE2 = 'https://picsum.photos/id/215/900/500';
+const TARGET = 'https://i.imgur.com/WWcQlwR.png';
 
 const CROP_AREA_WIDTH = w;
 const CROP_AREA_HEIGHT = h;
@@ -53,7 +54,7 @@ const styles = StyleSheet.create({
 
 class App extends React.Component {
   state = {
-    image: IMAGE,
+    image: TARGET,
     cropperParams: {},
     croppedImage: '',
   };
@@ -124,6 +125,16 @@ class App extends React.Component {
           cropAreaHeight={CROP_AREA_HEIGHT}
           setCropperParams={this.setCropperParams}
           areaOverlay={Overlay}
+          cropArea={{
+            offset: {
+              x: 0.125 * CROP_AREA_WIDTH,
+              y: 0.125 * CROP_AREA_HEIGHT,
+            },
+            size: {
+              width: 0.75 * CROP_AREA_WIDTH,
+              height: 0.75 * CROP_AREA_HEIGHT,
+            },
+          }}
         />
         <View style={styles.buttonContainer}>
           <Button onPress={this.handlePress} title="Crop Image" color="blue" />

--- a/src/ImageCropper.tsx
+++ b/src/ImageCropper.tsx
@@ -11,6 +11,7 @@ import {
   ICropParams,
   IImageViewerData,
   ISizeData,
+  IConstraints,
 } from './types';
 
 interface IProps {
@@ -21,6 +22,7 @@ interface IProps {
   areaColor?: string;
   areaOverlay?: ReactNode;
   setCropperParams: (params: ICropperParams) => void;
+  cropArea?: IConstraints;
 }
 
 export interface IState {
@@ -57,6 +59,7 @@ class ImageCropper extends PureComponent<IProps, IState> {
       cropSize,
       cropAreaSize,
       imageUri,
+      cropArea,
     } = params;
 
     const offset = {
@@ -69,6 +72,7 @@ class ImageCropper extends PureComponent<IProps, IState> {
 
     const wScale = cropAreaW / scale;
     const hScale = cropAreaH / scale;
+
 
     const percentCropperAreaW = getPercentDiffNumberFromNumber(
       wScale,
@@ -179,7 +183,12 @@ class ImageCropper extends PureComponent<IProps, IState> {
     Image.getSize(
       imageUri,
       (width, height) => {
-        const { setCropperParams, cropAreaWidth, cropAreaHeight } = this.props;
+        const {
+          setCropperParams,
+          cropAreaWidth,
+          cropAreaHeight,
+          cropArea,
+        } = this.props;
 
         const areaWidth = cropAreaWidth!;
         const areaHeight = cropAreaHeight!;
@@ -232,6 +241,7 @@ class ImageCropper extends PureComponent<IProps, IState> {
               scale,
               srcSize,
               fittedSize,
+              cropArea,
             });
           },
         );
@@ -241,7 +251,7 @@ class ImageCropper extends PureComponent<IProps, IState> {
   };
 
   handleMove = ({ positionX, positionY, scale }: IImageViewerData) => {
-    const { setCropperParams } = this.props;
+    const { setCropperParams, cropArea } = this.props;
 
     this.setState(
       prevState => ({
@@ -259,6 +269,7 @@ class ImageCropper extends PureComponent<IProps, IState> {
           scale,
           srcSize,
           fittedSize,
+          cropArea,
         });
       },
     );
@@ -273,6 +284,7 @@ class ImageCropper extends PureComponent<IProps, IState> {
       containerColor,
       areaColor,
       areaOverlay,
+      cropArea,
     } = this.props;
 
     const areaWidth = cropAreaWidth!;
@@ -288,11 +300,12 @@ class ImageCropper extends PureComponent<IProps, IState> {
         areaHeight={areaHeight}
         imageWidth={imageWidth}
         imageHeight={imageHeight}
-        minScale={minScale}
+        minScale={undefined}
         onMove={this.handleMove}
         containerColor={containerColor}
         imageBackdropColor={areaColor}
         overlay={areaOverlay}
+        constraints={cropArea}
       />
     ) : null;
   }

--- a/src/ImageViewer.tsx
+++ b/src/ImageViewer.tsx
@@ -183,7 +183,7 @@ class ImageViewer extends Component<IProps> {
       constraintsValues.size.height,
     );
     const translateYMin = divide(
-      sub(bottomMarginY, scaledWidth, scalingOriginShiftY),
+      sub(bottomMarginY, scaledHeight, scalingOriginShiftY),
       this.scale,
     );
 

--- a/src/ImageViewer.tsx
+++ b/src/ImageViewer.tsx
@@ -6,7 +6,7 @@ import {
   PinchGestureHandler,
   State,
 } from 'react-native-gesture-handler';
-import Animated, { Easing, max, debug } from 'react-native-reanimated';
+import Animated, { Easing, max } from 'react-native-reanimated';
 import { timing } from 'react-native-redash';
 import { IImageViewerData, IConstraints } from './types';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,10 +15,22 @@ export interface ICropperParams {
   scale: number;
   srcSize: ISizeData;
   fittedSize: ISizeData;
+  cropArea?: IConstraints;
 }
 
 export interface ICropParams extends ICropperParams {
   cropSize: ISizeData;
   cropAreaSize: ISizeData;
   imageUri: string;
+}
+
+export interface IConstraints {
+  offset: {
+    x: number;
+    y: number;
+  };
+  size: {
+    width: number;
+    height: number;
+  };
 }


### PR DESCRIPTION
Follow up of #22 

This PR adds a `cropArea` option that allows to define the cropping area within the area:
- [x] Let image viewer move the image freely within `cropArea`'s constraints
- [ ] Modify crop function to crop following `cropArea` option

I'm now struggling with the second todo. I would appreciate some guidance!